### PR TITLE
Fix typo in name for update.ini file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Database that will help you get a few console and computer BIOS that a
 
 If you use [Update All](https://github.com/theypsilon/Update_All_MiSTer), you may simply activate it there in the Settings Screen.
 
-Alternatively, if you don't use it, you can add an entry to the `downloader.ini` file on the root of your SD (create it if it doesn't exist), to use it with the [MiSTer Downloader](https://github.com/MiSTer-devel/Downloader_MiSTer/) (which is what Update All calls under the hood). For that, please add the following entry there:
+Alternatively, if you don't use it, you can add an entry to the `update.ini` file on the root of your SD (create it if it doesn't exist), to use it with the [MiSTer Downloader](https://github.com/MiSTer-devel/Downloader_MiSTer/) (which is what Update All calls under the hood). For that, please add the following entry there:
 
 ```
 [bios_db]


### PR DESCRIPTION
After a couple failed attempts using downloader.ini for the filename, I noticed that the console actually referred to update.ini, tried that, and it worked